### PR TITLE
setopt SH_WORDSPLIT for ZSH compat

### DIFF
--- a/gpgbridge_helper.sh
+++ b/gpgbridge_helper.sh
@@ -19,14 +19,16 @@ LOGFILE_WIN="${LOGFILE_WIN:-$SCRIPT_DIR_WSL/gpgbridge_win.log}"
 #---------------------------------------------------------------------------
 # Do not edit below this line
 
-touch "$PIDFILE_WIN" "$LOGFILE_WIN" # Needs to be created otherwise wslpath complains
+touch "$PIDFILE_WIN" "$LOGFILE_WIN"  # Needs to be created otherwise wslpath complains
 PIDFILE_WIN="$(wslpath -wa "$PIDFILE_WIN")"
 LOGFILE_WIN="$(wslpath -wa "$LOGFILE_WIN")"
 
-start_gpgbridge() {
-    if ! command -v ruby.exe >/dev/null; then
-        echo 'No ruby.exe found in path'
-        return 1
+start_gpgbridge()
+{
+    if ! command -v ruby.exe >/dev/null
+    then
+	echo 'No ruby.exe found in path'
+	return 1
     fi
 
     # Parse arguments
@@ -34,10 +36,10 @@ start_gpgbridge() {
     _parsed_args=$(getopt -a -n start_gpgbridge -o h --long ssh,wsl2,help -- "$@")
     _is_args_valid=$?
 
-    if [ ! $_is_args_valid ]; then
-        echo "Usage: start_gpgbridge [ --ssh ] [ --wsl2 ]"
-        unset _parsed_args _is_args_valid
-        exit 1
+    if [ ! $_is_args_valid ] ; then
+	echo "Usage: start_gpgbridge [ --ssh ] [ --wsl2 ]"
+	unset _parsed_args _is_args_valid
+	exit 1
     fi
 
     # Defaults for ruby arguments
@@ -45,23 +47,23 @@ start_gpgbridge() {
     _remote_ip="127.0.0.1"
 
     eval set -- "$_parsed_args"
-    while :; do
-        case "$1" in
-        --ssh)
-            _ssh_arg="--enable-ssh-support"
-            SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
-            export SSH_AUTH_SOCK
-            shift
-            ;;
-        --wsl2)
-            _remote_ip="$(ip route | awk '/^default via / {print $3}')"
-            shift
-            ;;
-        --)
-            shift
-            break
-            ;;
-        esac
+    while :
+    do
+	case "$1" in
+	    --ssh)
+        _ssh_arg="--enable-ssh-support"
+		SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+		export SSH_AUTH_SOCK
+		shift
+		;;
+	    --wsl2)
+		_remote_ip="$(ip route | awk '/^default via / {print $3}')"
+		shift
+		;;
+	    --)
+		shift
+		break
+	esac
     done
 
     ruby "$SCRIPT_DIR_WSL/gpgbridge.rb" \
@@ -76,12 +78,14 @@ start_gpgbridge() {
     unset _parsed_args _is_args_valid _ssh_arg _remote_ip
 }
 
-stop_gpgbridge() {
+stop_gpgbridge()
+{
     # Kill gpgbridge if running, else return
     pkill -TERM -f 'ruby.*gpgbridge\.rb' || return 0
 }
 
-restart_gpgbridge() {
+restart_gpgbridge()
+{
     stop_gpgbridge
     sleep 1
     start_gpgbridge "$@"

--- a/gpgbridge_helper.sh
+++ b/gpgbridge_helper.sh
@@ -42,19 +42,22 @@ start_gpgbridge()
 	exit 1
     fi
 
-    _opts=''
+    # Defaults for ruby arguments
+    _ssh_arg="--no-enable-ssh-support"
+    _remote_ip="127.0.0.1"
+
     eval set -- "$_parsed_args"
     while :
     do
 	case "$1" in
 	    --ssh)
-		_opts="$_opts --enable-ssh-support"
+        _ssh_arg="--enable-ssh-support"
 		SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
 		export SSH_AUTH_SOCK
 		shift
 		;;
 	    --wsl2)
-		_opts="$_opts --remote-address $(ip route | awk '/^default via / {print $3}')"
+		_remote_ip="$(ip route | awk '/^default via / {print $3}')"
 		shift
 		;;
 	    --)
@@ -63,8 +66,16 @@ start_gpgbridge()
 	esac
     done
 
-    ruby "$SCRIPT_DIR_WSL/gpgbridge.rb" --daemon --pidfile "$PIDFILE_WSL" --logfile "$LOGFILE_WSL" --windows-pidfile "$PIDFILE_WIN" --windows-logfile "$LOGFILE_WIN" ${_opts}
-    unset _parsed_args _is_args_valid _opts
+    ruby "$SCRIPT_DIR_WSL/gpgbridge.rb" \
+        --daemon \
+        --pidfile "$PIDFILE_WSL" \
+        --logfile "$LOGFILE_WSL" \
+        --windows-pidfile "$PIDFILE_WIN" \
+        --windows-logfile "$LOGFILE_WIN" \
+        "$_ssh_arg" \
+        --remote-address "$_remote_ip"
+
+    unset _parsed_args _is_args_valid _ssh_arg _remote_ip
 }
 
 stop_gpgbridge()

--- a/gpgbridge_helper.sh
+++ b/gpgbridge_helper.sh
@@ -19,16 +19,14 @@ LOGFILE_WIN="${LOGFILE_WIN:-$SCRIPT_DIR_WSL/gpgbridge_win.log}"
 #---------------------------------------------------------------------------
 # Do not edit below this line
 
-touch "$PIDFILE_WIN" "$LOGFILE_WIN"  # Needs to be created otherwise wslpath complains
+touch "$PIDFILE_WIN" "$LOGFILE_WIN" # Needs to be created otherwise wslpath complains
 PIDFILE_WIN="$(wslpath -wa "$PIDFILE_WIN")"
 LOGFILE_WIN="$(wslpath -wa "$LOGFILE_WIN")"
 
-start_gpgbridge()
-{
-    if ! command -v ruby.exe >/dev/null
-    then
-	echo 'No ruby.exe found in path'
-	return 1
+start_gpgbridge() {
+    if ! command -v ruby.exe >/dev/null; then
+        echo 'No ruby.exe found in path'
+        return 1
     fi
 
     # Parse arguments
@@ -36,10 +34,10 @@ start_gpgbridge()
     _parsed_args=$(getopt -a -n start_gpgbridge -o h --long ssh,wsl2,help -- "$@")
     _is_args_valid=$?
 
-    if [ ! $_is_args_valid ] ; then
-	echo "Usage: start_gpgbridge [ --ssh ] [ --wsl2 ]"
-	unset _parsed_args _is_args_valid
-	exit 1
+    if [ ! $_is_args_valid ]; then
+        echo "Usage: start_gpgbridge [ --ssh ] [ --wsl2 ]"
+        unset _parsed_args _is_args_valid
+        exit 1
     fi
 
     # Defaults for ruby arguments
@@ -47,23 +45,23 @@ start_gpgbridge()
     _remote_ip="127.0.0.1"
 
     eval set -- "$_parsed_args"
-    while :
-    do
-	case "$1" in
-	    --ssh)
-        _ssh_arg="--enable-ssh-support"
-		SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
-		export SSH_AUTH_SOCK
-		shift
-		;;
-	    --wsl2)
-		_remote_ip="$(ip route | awk '/^default via / {print $3}')"
-		shift
-		;;
-	    --)
-		shift
-		break
-	esac
+    while :; do
+        case "$1" in
+        --ssh)
+            _ssh_arg="--enable-ssh-support"
+            SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+            export SSH_AUTH_SOCK
+            shift
+            ;;
+        --wsl2)
+            _remote_ip="$(ip route | awk '/^default via / {print $3}')"
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        esac
     done
 
     ruby "$SCRIPT_DIR_WSL/gpgbridge.rb" \
@@ -78,14 +76,12 @@ start_gpgbridge()
     unset _parsed_args _is_args_valid _ssh_arg _remote_ip
 }
 
-stop_gpgbridge()
-{
+stop_gpgbridge() {
     # Kill gpgbridge if running, else return
     pkill -TERM -f 'ruby.*gpgbridge\.rb' || return 0
 }
 
-restart_gpgbridge()
-{
+restart_gpgbridge() {
     stop_gpgbridge
     sleep 1
     start_gpgbridge "$@"

--- a/gpgbridge_helper.sh
+++ b/gpgbridge_helper.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 #--------------------------------------------------------------------------
 # GPG bridging from WSL gpg to gpg4win gpg-agent.exe
 # (needed to use a Yubikey, since WSL cannot access USB devices)
@@ -18,10 +17,6 @@ LOGFILE_WIN="${LOGFILE_WIN:-$SCRIPT_DIR_WSL/gpgbridge_win.log}"
 
 #---------------------------------------------------------------------------
 # Do not edit below this line
-
-touch "$PIDFILE_WIN" "$LOGFILE_WIN"  # Needs to be created otherwise wslpath complains
-PIDFILE_WIN="$(wslpath -wa "$PIDFILE_WIN")"
-LOGFILE_WIN="$(wslpath -wa "$LOGFILE_WIN")"
 
 start_gpgbridge()
 {
@@ -66,7 +61,8 @@ start_gpgbridge()
     # Only applies to ZSH and command not found in (ba)sh
     setopt shwordsplit 2>/dev/null ||
 
-    ruby "$SCRIPT_DIR_WSL/gpgbridge.rb" --daemon --pidfile "$PIDFILE_WSL" --logfile "$LOGFILE_WSL" --windows-pidfile "$PIDFILE_WIN" --windows-logfile "$LOGFILE_WIN" ${_opts}
+    touch "$PIDFILE_WIN" "$LOGFILE_WIN"  # Needs to exist otherwise wslpath complains
+    ruby "$SCRIPT_DIR_WSL/gpgbridge.rb" --daemon --pidfile "$PIDFILE_WSL" --logfile "$LOGFILE_WSL" --windows-pidfile "$(wslpath -wa "$PIDFILE_WIN")" --windows-logfile "$(wslpath -wa "$LOGFILE_WIN")" ${_opts}
 
     unsetopt shwordsplit 2>/dev/null ||
 


### PR DESCRIPTION
Here's what gets executed for me when I run `start_gpgbridge --ssh --wsl` after sourcing `gpgbridge_helper.se` (from looking at the output of set -x):
```
ruby /mnt/c/Users/a/.gpgbridge/repo/gpgbridge.rb --daemon --pidfile /home/tetov/.gpgbridge_wsl.pid --logfile /home/tetov/.gpgbridge_wsl.log --windows-pidfile 'C:\Users\a\.gpgbridge\gpgbridge_win.pid' --windows-logfile 'C:\Users\a\.gpgbridge\gpgbridge_win.log' ' --enable-ssh-support --remote-address 172.18.192.1'
```
Here's what's get logged:
```
#<Thread:0x000055e404753738 /mnt/c/Users/a/.gpgbridge/repo/gpgbridge.rb:96 run> terminated with exception (report_on_exception is true):
/mnt/c/Users/a/.gpgbridge/repo/gpgbridge.rb:100:in `initialize': Connection refused - connect(2) for "127.0.0.1" port 6910 (Errno::ECONNREFUSED)
        from /mnt/c/Users/a/.gpgbridge/repo/gpgbridge.rb:100:in `new'
        from /mnt/c/Users/a/.gpgbridge/repo/gpgbridge.rb:100:in `block (2 levels) in start_listener'
```
 
The log shows a connection attempt to `127.0.0.1` which leads me to think that the ruby argument is not getting parsed correctly. I think it's due to the quoting `[...] ' --enable-ssh-support --remote-address 172.18.192.1'`. This could probably be fixed by playing with [IFS](https://en.wikipedia.org/wiki/Input_Field_Separators) but this fix instead just avoids strings with spaces haha!